### PR TITLE
修复open弹窗再关闭后浏览器控制台报错

### DIFF
--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -840,6 +840,9 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
                                 '</style>');
                         });
                     }
+                },
+                end: function () {
+                    index = null
                 }
             });
             if (admin.checkMobile() || width === undefined || height === undefined) {
@@ -847,7 +850,7 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
             }
             if (isResize) {
                 $(window).on("resize", function () {
-                    layer.full(index);
+                    index && layer.full(index);
                 })
             }
         },


### PR DESCRIPTION
open弹窗关闭后，window.resize 绑定的事件和 layer弹窗的索引还在，会导致出现 “ Uncaught TypeError: Cannot read property 'top' of undefined” 的错误。
修改代码，在open弹窗关闭后对layer弹窗索引进行销毁