### PR TITLE
让data-open弹出层支持打开自定义url

### DIFF
--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -913,6 +913,7 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
                     dataFull = $(this).attr('data-full'),
                     checkbox = $(this).attr('data-checkbox'),
                     url = $(this).attr('data-open'),
+                    external = $(this).attr('data-external') || false,
                     tableId = $(this).attr('data-table');
 
                 if(checkbox === 'true'){
@@ -952,7 +953,7 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
 
                 admin.open(
                     $(this).attr('data-title'),
-                    admin.url(url),
+                    external ? url : admin.url(url),
                     clienWidth,
                     clientHeight,
                 );


### PR DESCRIPTION
使用时追加参数：data-external="true"，即可打开https://www.baidu.com等外部url