### PR TITLE
自定义表格opreat按钮的弹窗标题风格

### DIFF
--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -584,6 +584,13 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
                             operat.title = operat.title || operat.text;
                             operat.text = operat.text || operat.title;
                             operat.extend = operat.extend || '';
+                            
+                            // 自定义表格opreat按钮的弹窗标题风格，extra是表格里的欲加入标题中的字段
+                            operat.extra = operat.extra || '';
+                            if (data[operat.extra] !== undefined) {
+                                operat.title = data[operat.extra] + ' - ' + operat.title;
+                            }
+                            
                             operat.url = admin.table.toolSpliceUrl(operat.url, operat.field, data);
                             if (admin.checkAuth(operat.auth, elem)) {
                                 html += admin.table.buildOperatHtml(operat);


### PR DESCRIPTION
自定义表格opreat按钮的弹窗标题风格，extra是表格里的欲加入标题中的字段
使用方法：
![image](https://user-images.githubusercontent.com/29515610/130250719-14f11def-e95a-4588-a413-8f3a0e7e5ca6.png)

弹窗标题将变为：
![image](https://user-images.githubusercontent.com/29515610/130250770-cde353e5-43b1-4e1e-a1ef-fac77ce689aa.png)
