### PR TITLE
Mod: 增加动态控制列表某个操作按钮是否渲染

### DIFF
--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -597,7 +597,11 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
 
                             operat.url = admin.table.toolSpliceUrl(operat.url, operat.field, data);
                             if (admin.checkAuth(operat.auth, elem)) {
-                                html += admin.table.buildOperatHtml(operat);
+                                if (typeof operat.render === 'function') {
+                                    html += operat.render(data, option) ? admin.table.buildOperatHtml(operat) : '';
+                                } else {
+                                    html += admin.table.buildOperatHtml(operat);
+                                }
                             }
                         });
                     }


### PR DESCRIPTION
用来动态控制表格某一行的某个按钮元素是否显示
比如有打印小票权限时，列表中只有待打印状态的才显示打印按钮
只需配置 render 参数，对应的回调函数返回布尔值即可
使用方法如图：[https://foruda.gitee.com/images/1664253526289692405/856bcb80_5507348.png](https://foruda.gitee.com/images/1664253526289692405/856bcb80_5507348.png)
效果展示如图：[https://foruda.gitee.com/images/1664253098250117486/d6c85a37_5507348.png](https://foruda.gitee.com/images/1664253098250117486/d6c85a37_5507348.png)
