### PR TITLE
Mod: 修改[data-image]属性监听，支持放大一组图片

### DIFF
--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -625,7 +625,7 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
                 option.imageJoin = option.imageJoin || '<br>';
                 option.title = option.title || option.field;
                 var field = option.field,
-                    title = data[option.title];
+                    title = data[option.title] ? data[option.title] : option.title;
                 try {
                     var value = eval("data." + field);
                 } catch (e) {
@@ -972,20 +972,32 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
 
             // 放大图片
             $('body').on('click', '[data-image]', function () {
-                var title = $(this).attr('data-image'),
-                    src = $(this).attr('src'),
-                    alt = $(this).attr('alt');
+                var currentSrc = $(this).attr('src'),
+                    start = 0,
+                    data = [];
+
+                $(this).parent().children('[data-image]').each(function (i, v) {
+                    var title = $(this).attr('data-image'),
+                        alt = $(this).attr('alt'),
+                        src = $(this).attr('src');
+
+                    data.push({
+                        "alt": alt ? alt : title,
+                        "pid": Math.random(),
+                        "src": src,
+                        "thumb": src
+                    });
+
+                    if (currentSrc === src) {
+                        start = i;
+                    }
+                });
+
                 var photos = {
-                    "title": title,
+                    "title": '',
+                    "start": start,
                     "id": Math.random(),
-                    "data": [
-                        {
-                            "alt": alt,
-                            "pid": Math.random(),
-                            "src": src,
-                            "thumb": src
-                        }
-                    ]
+                    "data": data
                 };
                 layer.photos({
                     photos: photos,


### PR DESCRIPTION
如果同一个父元素下有多个[data-image]元素，点击放大一张图后，可左右切换多图
PS：之前提交过一个[PR](https://github.com/zhongshaofa/easyadmin/pull/93/commits)且是被合并了的，估计是代码合并时又被覆盖了，导致v2分支上没有这段代码，所以再提交一次