### PR TITLE
Fix: 修复列表检索条件有关联查询时，字段名带点号比如 category.id, 设置的 searchOp 配置参数不生效问题

### DIFF
--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -728,7 +728,7 @@ define(["jquery", "tableSelect", "ckeditor"], function ($, tableSelect, undefine
                     $.each(dataField, function (key, val) {
                         if (val !== '') {
                             formatFilter[key] = val;
-                            var op = $('#c-' + key).attr('data-search-op');
+                            var op = $('[id=\'c-' + key + '\']').attr('data-search-op');
                             op = op || '%*%';
                             formatOp[key] = op;
                         }


### PR DESCRIPTION
操作复现，如图 [https://foruda.gitee.com/images/1664257928530244144/cd28288d_5507348.png](https://foruda.gitee.com/images/1664257928530244144/cd28288d_5507348.png)