### PR TITLE
修复 php三元表达式的执行顺序

### DIFF
--- a/app/common.php
+++ b/app/common.php
@@ -54,7 +54,7 @@ if (!function_exists('xdebug')) {
             $file = is_null($suffix) ? runtime_path() . 'xdebug/' . date('Ymd') . '.txt' : runtime_path() . 'xdebug/' . date('Ymd') . "_{$suffix}" . '.txt';
         }
         file_put_contents($file, "[" . date('Y-m-d H:i:s') . "] " . "========================= {$type} ===========================" . PHP_EOL, FILE_APPEND);
-        $str = (is_string($data) ? $data : (is_array($data) || is_object($data)) ? print_r($data, true) : var_export($data, true)) . PHP_EOL;
+        $str = (is_string($data) ? $data :( (is_array($data) || is_object($data)) ? print_r($data, true) : var_export($data, true)) . PHP_EOL);
         $force ? file_put_contents($file, $str) : file_put_contents($file, $str, FILE_APPEND);
     }
 }


### PR DESCRIPTION
PHP Deprecated:  Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in /Users/hainuo/Downloads/MyWork/app/common.php on line 57

修复以上问题 避免在后续的php版本中报错