### PR TITLE
fix: 修复菜单链接带问号时，节点权限匹配不成功的问题

### DIFF
--- a/app/common/service/AuthService.php
+++ b/app/common/service/AuthService.php
@@ -197,6 +197,7 @@ class AuthService
      */
     public function parseNodeStr($node)
     {
+        $node = explode('?', $node)[0];
         $array = explode('/', $node);
         foreach ($array as $key => $val) {
             if ($key == 0) {


### PR DESCRIPTION
添加菜单的时候，如果菜单中包含问号，如：
```
link/index?type=1
```
这个时候权限匹配会匹配不到 “link/index”