### PR TITLE
[fix]修复管理员列表-设置密码-页面被拦截

### DIFF
--- a/app/admin/controller/system/Admin.php
+++ b/app/admin/controller/system/Admin.php
@@ -128,7 +128,6 @@ class Admin extends AdminController
      */
     public function password($id)
     {
-        $this->checkPostRequest();
         $row = $this->model->find($id);
         empty($row) && $this->error('数据不存在');
         if ($this->request->isAjax()) {


### PR DESCRIPTION
get请求被意外拦截，导致设置密码页面打不开