### PR TITLE
Mod: 增加ea.js的image方法图片加载失败时的处理

### DIFF
--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -666,12 +666,12 @@ define(["jquery", "tableSelect","xmSelect", "ckeditor"], function ($, tableSelec
                     var value = undefined;
                 }
                 if (value === undefined || value===null) {
-                    return '<img style="max-width: ' + option.imageWidth + 'px; max-height: ' + option.imageHeight + 'px;" src="' + value + '" data-image="' + title + '">';
+                    return '<img style="max-width: ' + option.imageWidth + 'px; max-height: ' + option.imageHeight + 'px;" src="' + value + '" data-image="' + title + '" onerror="this.src=\'' + BASE_URL + 'admin/images/upload-icons/image.png\'">';
                 } else {
                     var values = value.split(option.imageSplit),
                         valuesHtml = [];
                     values.forEach((value, index) => {
-                        valuesHtml.push('<img style="max-width: ' + option.imageWidth + 'px; max-height: ' + option.imageHeight + 'px;" src="' + value + '" data-image="' + title + '">');
+                        valuesHtml.push('<img style="max-width: ' + option.imageWidth + 'px; max-height: ' + option.imageHeight + 'px;" src="' + value + '" data-image="' + title + '" onerror="this.src=\'' + BASE_URL + 'admin/images/upload-icons/image.png\'">');
                     });
                     return valuesHtml.join(option.imageJoin);
                 }


### PR DESCRIPTION
主要场景：

- 当图片加载失败时
- 当在tableSelect.js插件展示的文件选择列表中，有非图片的上传记录时

以上加载失败的场景会显示系统默认图片
如图：[https://foruda.gitee.com/images/1664257314575907237/cf7ed93e_5507348.png](https://foruda.gitee.com/images/1664257314575907237/cf7ed93e_5507348.png)