### PR TITLE
Fix: 修复[data-images]放大一组图片展示顺序问题

### DIFF
--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -1030,35 +1030,27 @@ define(["jquery", "tableSelect","xmSelect", "ckeditor"], function ($, tableSelec
 
             // 放大一组图片
             $('body').on('click', '[data-images]', function () {
-                var title = $(this).attr('data-images'),
-                    // 从当前元素向上找layuimini-upload-show找到第一个后停止, 再找其所有子元素li
-                    doms = $(this).closest(".layuimini-upload-show").children("li"),
-                    // 被点击的图片地址
-                    now_src = $(this).attr('src'),
-                    alt = $(this).attr('alt'),
+                var doms = $(this).closest(".layuimini-upload-show").children("li"),  // 从当前元素向上找layuimini-upload-show找到第一个后停止, 再找其所有子元素li
+                    currentSrc = $(this).attr('src'), // 被点击的图片地址
+                    start = 0,
                     data = [];
-                $.each(doms, function(key, value){
-                    var src = $(value).find('img').attr('src');
-                    if(src != now_src){
-                        // 压入其他图片地址
-                        data.push({
-                            "alt": alt,
-                            "pid": Math.random(),
-                            "src": src,
-                            "thumb": src
-                        });
-                    }else{
-                        // 把当前图片插入到头部
-                        data.unshift({
-                            "alt": alt,
-                            "pid": Math.random(),
-                            "src": now_src,
-                            "thumb": now_src
-                        });
+                $.each(doms, function (key, value) {
+                    var img = $(value).find('img'),
+                        src = img.attr('src'),
+                        alt = img.attr('alt');
+                    data.push({
+                        "alt": alt,
+                        "pid": Math.random(),
+                        "src": src,
+                        "thumb": src
+                    });
+                    if (src === currentSrc) {
+                        start = key;
                     }
                 });
                 var photos = {
-                    "title": title,
+                    "title": '',
+                    "start": start,
                     "id": Math.random(),
                     "data": data,
                 };


### PR DESCRIPTION
比如 点击的图片是第2张，那么下标应该是2，而不是永远是1