### PR TITLE
Fix: 修复菜单管理的一些问题

### DIFF
--- a/app/admin/controller/system/Menu.php
+++ b/app/admin/controller/system/Menu.php
@@ -118,6 +118,10 @@ class Menu extends AdminController
                 'icon|菜单图标'  => 'require',
             ];
             $this->validate($post, $rule);
+            //防止首页pid被修改而导致渲染时报错
+            if ($row->pid == MenuConstant::HOME_PID) {
+                unset($post['pid']);
+            }
             try {
                 $save = $row->save($post);
             } catch (\Exception $e) {

--- a/public/static/plugs/easy-admin/easy-admin.js
+++ b/public/static/plugs/easy-admin/easy-admin.js
@@ -471,6 +471,8 @@ define(["jquery", "tableSelect","xmSelect", "ckeditor"], function ($, tableSelec
                     formatToolbar.method = formatToolbar.method !== '' ? 'data-open="' + formatToolbar.url + '" data-title="' + formatToolbar.title + '" ' : '';
                 } else if (toolbar.method === 'none'){ // 常用于与extend配合，自定义监听按钮
                     formatToolbar.method = '';
+                } else if (toolbar.method === 'url') { // 与extend配合自定义监听url的处理方式
+                    formatToolbar.method = formatToolbar.method !== '' ? 'data-url="' + formatToolbar.url + '" data-title="' + formatToolbar.title + '" ' : '';
                 } else {
                     formatToolbar.method = formatToolbar.method !== '' ? 'data-request="' + formatToolbar.url + '" data-title="' + formatToolbar.title + '" ' : '';
                 }
@@ -499,6 +501,8 @@ define(["jquery", "tableSelect","xmSelect", "ckeditor"], function ($, tableSelec
                     formatOperat.method = formatOperat.method !== '' ? 'data-open="' + formatOperat.url + '" data-title="' + formatOperat.title + '" ' : '';
                 } else if (operat.method === 'none'){ // 常用于与extend配合，自定义监听按钮
                     formatOperat.method = '';
+                } else if (operat.method === 'url') { // 与extend配合自定义监听url的处理方式
+                    formatOperat.method = formatOperat.method !== '' ? 'data-url="' + formatOperat.url + '" data-title="' + formatOperat.title + '" ' : '';
                 } else {
                     formatOperat.method = formatOperat.method !== '' ? 'data-request="' + formatOperat.url + '" data-title="' + formatOperat.title + '" ' : '';
                 }


### PR DESCRIPTION
- 修复 编辑“后台首页”按保存后，会修改首页菜单pid，从而导致系统初始化再次系统时 homeInfo 数据为 null，报 Cannot read properties of null (reading 'href') 错误
- 修复 删除单个菜单后，treetable 不会刷新问题
- 修复 修改菜单信息后，treetable 不会刷新问题，比如修改排序后不会自动刷新
- 修复 修改菜单状态后，treetable 不会刷新问题