### PR TITLE
Fix: 修复当菜单链接带query部分时,节点权限匹配失败问题

### DIFF
--- a/app/common/service/AuthService.php
+++ b/app/common/service/AuthService.php
@@ -197,7 +197,7 @@ class AuthService
      */
     public function parseNodeStr($node)
     {
-        $array = explode('/', $node);
+        $array = explode('/', parse_url($node, PHP_URL_PATH));
         foreach ($array as $key => $val) {
             if ($key == 0) {
                 $val = explode('.', $val);


### PR DESCRIPTION
比如菜单链接为 order/index?timely=1 时，无法匹配节点 order/index，从而导致无法渲染这个菜单