### PR TITLE
Add: 增加向js文件传递变量的方法

### DIFF
--- a/app/admin/view/layout/default.html
+++ b/app/admin/view/layout/default.html
@@ -21,6 +21,7 @@
             VERSION: "{$version|default='1.0.0'}",
             CSRF_TOKEN: "{:token()}",
         };
+        window.$variables = {$jsVariables|raw|default='null'};
     </script>
     <script src="__STATIC__/plugs/layui-v2.5.6/layui.all.js?v={$version}" charset="utf-8"></script>
     <script src="__STATIC__/plugs/require-2.3.6/require.js?v={$version}" charset="utf-8"></script>

--- a/app/common/controller/AdminController.php
+++ b/app/common/controller/AdminController.php
@@ -104,6 +104,16 @@ class AdminController extends BaseController
     }
 
     /**
+     * 设置js变量
+     * @param array $data
+     * @return mixed
+     */
+    public function setJsVariables(array $data = [])
+    {
+        return $this->assign('jsVariables', json_encode($data));
+    }
+
+    /**
      * 模板变量赋值
      * @param string|array $name 模板变量
      * @param mixed $value 变量值


### PR DESCRIPTION
拿 EasyAmin 中的文件举例：

- Admin.php 控制中调用 `$this->setJsVariables('statusOptions', [0=>'禁用', 1=>'启用']);` 向 admin.js传递 js 变量；
- admin.js 文件中调用 `$variables.statusOptions` 就可以获取后 php 传递过来的 js 变量；
- 举个栗子比如在 admin.js 的 table 的 selectList 参数就可以不用写死了。 `{field: 'status', title: '状态', width: 85, search: 'select', selectList: {0: '禁用', 1: '启用'}, templet: ea.table.switch}` 改为 `{field: 'status', title: '状态', width: 85, search: 'select', selectList: $variables.statusOptions, templet: ea.table.switch}`,