### PR TITLE
Fix: 修复OssStatic命令上传含有目录的文件时文件未按目录存储问题

### DIFF
--- a/app/common/command/OssStatic.php
+++ b/app/common/command/OssStatic.php
@@ -38,7 +38,7 @@ class OssStatic extends Command
         $uploadConfig = sysconfig('upload');
         $uploadPrefix = config('app.oss_static_prefix', 'oss_static_prefix');
         foreach ($list as $key => $val) {
-            list($objectName, $filePath) = [$uploadPrefix . DIRECTORY_SEPARATOR . $key, $val];
+            list($objectName, $filePath) = [str_replace('\\', '/', $uploadPrefix . DIRECTORY_SEPARATOR . $key), $val];
             try {
                 $upload = Oss::instance($uploadConfig)
                     ->save($objectName, $filePath);


### PR DESCRIPTION
OssStatic 命令上传含有目录的文件时文件未按目录存储，而是把路径拼接成了一个文件名，如图：[https://foruda.gitee.com/images/1679733732125726804/d56fc7b0_5507348.jpeg](https://foruda.gitee.com/images/1679733732125726804/d56fc7b0_5507348.jpeg)